### PR TITLE
ignore unversioned database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@
 
 # Default Topology location
 sciwms/apps/wms/topology/
-
+sciwms/sci-wms.db
 !.gitkeep


### PR DESCRIPTION
Database is large binary file, specific to local versions of sciWMS, and changes often. git should ignore this file.
