### PR TITLE
LAYERS now standard_name, units had to be found via cf utility

### DIFF
--- a/sciwms/apps/wms/views.py
+++ b/sciwms/apps/wms/views.py
@@ -73,6 +73,8 @@ import numpy as np
 from .get_map import getMap
 from .get_feature_info import getFeatureInfo
 
+from ...util import cf
+
 output_path = os.path.join(settings.PROJECT_ROOT, 'logs', 'sciwms_wms.log')
 # Set up Logger
 logger = multiprocessing.get_logger()
@@ -950,7 +952,7 @@ def getLegendGraphic(request, dataset):
     Create the colorbar or legend and add to axis
     """
     try:
-        units = nc.variables[variables[0]].units
+        units = cf.get_by_standard_name(nc, variables[0]).units
     except:
         units = ''
     if climits[0] is None or climits[1] is None:  # TODO: NOT SUPPORTED RESPONSE


### PR DESCRIPTION
@brandonmayer have a quick look at this

We lost the "units" when we went to the standard_name in the WMS LAYERS argument. Have to use the cf 'get_by_standard_name' utility now to get the appropriate dataset and then the units for display in the legend

for comparison (valid 20141120):
http://comt.sura.org/proxy_8081/wms/datasets/inundation_tropical_UND_ADCIRC_Hurricane_Ike_2D_final_run_with_waves/?LAYERS=sea_surface_height_above_geoid&TRANSPARENT=TRUE&STYLES=pcolor_average_jet_0_7.0_grid_False&FORMAT=image%2Fpng&TIME=2008-09-05T12%3A00%3A00&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&SRS=EPSG%3A3857&LAYER=sea_surface_height_above_geoid

http://comt.sura.org/proxy_8080/wms/datasets/inundation_tropical_UND_ADCIRC_Hurricane_Ike_2D_final_run_with_waves/?LAYERS=sea_surface_height_above_geoid&TRANSPARENT=TRUE&STYLES=pcolor_average_jet_0_7.0_grid_False&FORMAT=image%2Fpng&TIME=2008-09-05T12%3A00%3A00&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&SRS=EPSG%3A3857&LAYER=sea_surface_height_above_geoid
